### PR TITLE
Deploy node v10 instead of v8

### DIFF
--- a/deploy/aws/user-data
+++ b/deploy/aws/user-data
@@ -2,7 +2,7 @@
 
 # update and install packages, reboot if necessary
 apt_sources:
-  - source: deb https://deb.nodesource.com/node_8.x bionic main
+  - source: deb https://deb.nodesource.com/node_10.x bionic main
     keyid: 1655a0ab68576280
 
 package_upgrade: true


### PR DESCRIPTION
We seem to have been hitting some SSL/TLS issues retrieving data from sprep.org
````
{ Error: write EPROTO 140246725322560:error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure:../deps/openssl/openssl/ssl/s23_clnt.c:802: at WriteWrap.afterWrite [as oncomplete] (net.js:868:14) errno: 'EPROTO', code: 'EPROTO', syscall: 'write' }
````

We didn't detect this locally because I, and most Terria folks are running node v10 and AWS deployments use node v8. This PR bumps up the deployed node version to 10.



